### PR TITLE
chore: release 0.5.0

### DIFF
--- a/lib/bandl/config.py
+++ b/lib/bandl/config.py
@@ -21,7 +21,7 @@ class BandlConfig(BaseModel):
 
     timeout_seconds: float = Field(default=30.0, ge=1.0)
     max_http_retries: int = Field(default=3, ge=0)
-    user_agent: str = Field(default="bandl/0.4 (+https://github.com/stockalgo/bandl)")
+    user_agent: str = Field(default="bandl/0.5 (+https://github.com/stockalgo/bandl)")
 
     # default provider ids per facet
     default_crypto_provider: str = "binance"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bandl"
-version = "0.4.0"
+version = "0.5.0"
 description = "Unified market data and account history with pluggable providers"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
Bump version `0.4.0` → `0.5.0` for the Dhan options provider + generic derivatives facet (#60).

- `pyproject.toml` `project.version` → `0.5.0`
- `BandlConfig.user_agent` → `bandl/0.5`

After merge: tag `v0.5.0` is moved to the merge commit and pushed, triggering the PyPI publish workflow (the tag-vs-pyproject version guard now passes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)