### PR TITLE
fix: stop blending Zerodha day-book pnl into net/holding sums

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -480,7 +480,7 @@ assert caps.supports("fills")
 
 **USE WHEN:** order history, executions, fees/funding, PnL.
 
-**COMMON PARAMS:** `start`, `end`, `source=None`, `symbol=`, `segment=`, `side=`, `status=`, `order_id=`, `limit=`. `get_pnl` adds `granularity=` (`trade`|`symbol`|`day`|`portfolio`), `prefer=` (`auto`|`broker`|`computed`|`hybrid`), `reconcile=False`.
+**COMMON PARAMS:** `start`, `end`, `source=None`, `symbol=`, `segment=`, `side=`, `status=`, `order_id=`, `limit=`. `get_pnl` adds `granularity=` (`trade`|`symbol`|`day`|`portfolio`), `prefer=` (`auto`|`broker`|`computed`|`hybrid`), `reconcile=False`, `scope=` (Zerodha only — see below).
 
 **RETURNS:** `list[AccountOrder]` / `list[AccountFill]` / `list[LedgerEntry]` / `list[PnLRecord]` (or DataFrames)
 
@@ -494,6 +494,20 @@ pnl   = client.account.get_pnl(start, end, source="zerodha", prefer="auto")
 ```
 
 **NOTES:** Zerodha orders/fills = **current session only**; holdings PnL ≈ lifetime snapshot, not arbitrary past months.
+
+**⚠️ Zerodha `get_pnl` day/net/holding scope — do not naively `sum()` without reading this:**
+Kite's `/portfolio/positions` returns two books, `net` (true running position economics) and `day` (today's session view — a position squared off intraday is costed against a **zero average price**, which can invert the sign of its reported pnl). `PnLRecord.scope` (`"day"|"net"|"holding"|None`) tags which book a row came from; rows with `zero_avg_price_artifact=True` are exactly the ones a zero-avg-price day-book row can fabricate.
+
+- `get_pnl(..., source="zerodha")` **default** returns `net` + `holding` scope only (day-book excluded) — **safe to `sum()`**.
+- Pass `scope="day"` to see Kite's day-book view; `scope="net"` / `scope="holding"` to isolate one book; `scope="all"` for everything.
+- **Never** mix `scope="day"` rows into a sum with `net`/`holding` rows — that's the exact bug this default guards against.
+- Prefer `client.account.get_pnl_summary(source="zerodha")` over hand-rolling this: it returns **one row per symbol**, already rolled up from the safe (day-excluded) scope — just sum `total_pnl` across the returned rows.
+
+```python
+# safe: one number per symbol, no day/net ambiguity to reason about
+summary = client.account.get_pnl_summary(source="zerodha")
+portfolio_total = sum(r.total_pnl for r in summary if r.total_pnl is not None)
+```
 
 ---
 
@@ -521,6 +535,7 @@ pnl   = client.account.get_pnl(start, end, source="zerodha", prefer="auto")
 | What expiries for an underlying | `client.derivatives.list_expiries("GOLDM", source="dhan", exchange="MCX")` | dhan | Yes |
 | Live option chain for a expiry | `client.derivatives.get_option_chain("GOLDM", expiry=date(...), source="dhan", exchange="MCX")` | dhan | Yes |
 | My CoinDCX futures PnL last month | `capabilities("coindcx")` then `get_pnl(..., source="coindcx", segment="crypto_fno")` | coindcx | Yes |
+| Total Zerodha pnl, safe to sum | `client.account.get_pnl_summary(source="zerodha")` — never sum raw `get_pnl(scope="all")` rows | zerodha | Yes |
 | Binance blocked in region | retry with `source="coindcx"` | coindcx | No |
 | CoinDCX empty candles | earlier `end`, or read `DataNotAvailableError` span | coindcx | No |
 | Compare brokers in one JSON | `export_analysis_bundle(start, end, sources=["coindcx","zerodha"])` | both | Yes |

--- a/lib/bandl/account/facet.py
+++ b/lib/bandl/account/facet.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterable
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import datetime, timezone
+from decimal import Decimal
 from typing import Any
 
 import pandas as pd
@@ -13,8 +15,9 @@ from bandl.core.capabilities import AccountCapabilities
 from bandl.core.dataframe import models_to_dataframe
 from bandl.core.provider import AccountHistoryProvider
 from bandl.exceptions import BandlError, ConfigurationError, UnsupportedCapabilityError
-from bandl.models.account import AccountFill, AccountOrder, LedgerEntry, PnLRecord
-from bandl.models.account.types import PnLGranularity
+from bandl.models.account import AccountFill, AccountOrder, LedgerEntry, PnLProvenance, PnLRecord
+from bandl.models.account.base import make_dedup_key
+from bandl.models.account.types import PnLConfidence, PnLGranularity, PnLSourceType
 
 
 def _to_dataframe(rows: list[Any]) -> pd.DataFrame:
@@ -26,6 +29,33 @@ def _merge_by_dedup(rows: list[Any]) -> list[Any]:
     for row in rows:
         seen[row.dedup_key] = row
     return list(seen.values())
+
+
+def _sum_optional(values: Iterable[Decimal | None]) -> Decimal | None:
+    """Sum non-``None`` values; ``None`` only if every value was ``None``."""
+    present = [v for v in values if v is not None]
+    if not present:
+        return None
+    return sum(present, Decimal(0))
+
+
+def _effective_total(r: PnLRecord) -> Decimal | None:
+    if r.total_pnl is not None:
+        return r.total_pnl
+    if r.realized_pnl is not None or r.unrealized_pnl is not None:
+        return (r.realized_pnl or Decimal(0)) + (r.unrealized_pnl or Decimal(0))
+    return None
+
+
+_CONFIDENCE_RANK: dict[str, int] = {
+    PnLConfidence.LOW: 0,
+    PnLConfidence.MEDIUM: 1,
+    PnLConfidence.HIGH: 2,
+}
+
+
+def _lowest_confidence(confidences: list[Any]) -> str:
+    return min(confidences, key=lambda c: _CONFIDENCE_RANK.get(c, 1))
 
 
 @dataclass
@@ -138,8 +168,13 @@ class AccountFacet:
         granularity: str = PnLGranularity.SYMBOL,
         prefer: str = "auto",
         reconcile: bool = False,
+        scope: str | None = None,
         **kwargs: Any,
     ) -> list[PnLRecord]:
+        """``scope``: ``None`` (default) excludes day-book rows — safe to sum.
+        Pass ``"day"``/``"net"``/``"holding"`` to isolate one book, or ``"all"``
+        for every row. See ``PnLRecord.scope`` / ``zero_avg_price_artifact``.
+        """
         filters = self._filters(start, end, **kwargs)
         rows: list[PnLRecord] = []
         for _, prov in self._providers_for(source):
@@ -149,12 +184,83 @@ class AccountFacet:
                     granularity=granularity,
                     prefer=prefer,
                     reconcile=reconcile,
+                    scope=scope,
                 ),
             )
         return _merge_by_dedup(rows)
 
     def get_pnl_dataframe(self, *args: Any, **kwargs: Any) -> pd.DataFrame:
         return _to_dataframe(self.get_pnl(*args, **kwargs))
+
+    def get_pnl_summary(
+        self,
+        start: datetime | None = None,
+        end: datetime | None = None,
+        *,
+        source: str | None = None,
+        prefer: str = "auto",
+        reconcile: bool = True,
+        **kwargs: Any,
+    ) -> list[PnLRecord]:
+        """One row per symbol, safe to ``sum()`` — rolls up whatever ``get_pnl()``'s
+        default (day-book-excluded) scope returns, so callers never need to
+        hand-roll day/net/holding reconciliation themselves.
+        """
+        rows = self.get_pnl(
+            start,
+            end,
+            source=source,
+            prefer=prefer,
+            reconcile=reconcile,
+            scope=None,
+            **kwargs,
+        )
+        by_symbol: dict[str, list[PnLRecord]] = {}
+        for r in rows:
+            by_symbol.setdefault(r.symbol, []).append(r)
+
+        now = datetime.now(timezone.utc)
+        summary: list[PnLRecord] = []
+        for sym, sym_rows in sorted(by_symbol.items()):
+            realized = _sum_optional(r.realized_pnl for r in sym_rows)
+            unrealized = _sum_optional(r.unrealized_pnl for r in sym_rows)
+            total = _sum_optional(_effective_total(r) for r in sym_rows)
+            sources = sorted({r.source for r in sym_rows})
+            confidences = [r.provenance.confidence for r in sym_rows]
+            summary.append(
+                PnLRecord(
+                    pnl_id=f"summary:{sym}",
+                    granularity=PnLGranularity.SYMBOL,
+                    scope=None,
+                    realized_pnl=realized,
+                    unrealized_pnl=unrealized,
+                    total_pnl=total,
+                    currency=sym_rows[0].currency,
+                    symbol=sym,
+                    as_of=now,
+                    provenance=PnLProvenance(
+                        source_type=PnLSourceType.HYBRID
+                        if len({r.provenance.source_type for r in sym_rows}) > 1
+                        else sym_rows[0].provenance.source_type,
+                        includes_fees=all(r.provenance.includes_fees for r in sym_rows),
+                        confidence=_lowest_confidence(confidences),
+                        warnings=[
+                            f"Rollup of {len(sym_rows)} row(s): "
+                            f"{', '.join(sorted({r.pnl_id for r in sym_rows}))}",
+                        ],
+                    ),
+                    source=sources[0] if len(sources) == 1 else "multiple",
+                    segment=sym_rows[0].segment,
+                    symbol_native=sym_rows[0].symbol_native,
+                    provider_native={},
+                    dedup_key=make_dedup_key("summary", "pnl", sym),
+                    metadata={"contributing_pnl_ids": sorted({r.pnl_id for r in sym_rows})},
+                ),
+            )
+        return summary
+
+    def get_pnl_summary_dataframe(self, *args: Any, **kwargs: Any) -> pd.DataFrame:
+        return _to_dataframe(self.get_pnl_summary(*args, **kwargs))
 
     def export_analysis_bundle(
         self,

--- a/lib/bandl/core/capabilities.py
+++ b/lib/bandl/core/capabilities.py
@@ -24,7 +24,6 @@ class AccountCapabilities(BaseModel):
     ledger: CapabilityDetail = Field(default_factory=CapabilityDetail)
     pnl_broker: CapabilityDetail = Field(default_factory=CapabilityDetail)
     pnl_computed: CapabilityDetail = Field(default_factory=CapabilityDetail)
-    positions: CapabilityDetail = Field(default_factory=CapabilityDetail)
 
     def supports(self, capability: str) -> bool:
         detail = getattr(self, capability, None)

--- a/lib/bandl/core/provider.py
+++ b/lib/bandl/core/provider.py
@@ -80,6 +80,7 @@ class AccountHistoryProvider(Protocol):
         granularity: str,
         prefer: str = "auto",
         reconcile: bool = False,
+        scope: str | None = None,
     ) -> list[PnLRecord]: ...
 
 

--- a/lib/bandl/models/account/pnl.py
+++ b/lib/bandl/models/account/pnl.py
@@ -2,12 +2,14 @@ from __future__ import annotations
 
 from datetime import datetime
 from decimal import Decimal
-from typing import Any
+from typing import Any, Literal
 
 from pydantic import BaseModel, Field
 
 from bandl.models.account.base import AccountEntityBase
 from bandl.models.account.types import PnLConfidence, PnLSourceType
+
+PnLScope = Literal["day", "net", "holding"]
 
 
 class PnLProvenance(BaseModel):
@@ -36,3 +38,15 @@ class PnLRecord(AccountEntityBase):
     as_of: datetime
     provenance: PnLProvenance
     metadata: dict[str, Any] = Field(default_factory=dict)
+
+    # Which broker "book" this row's economics come from. ``None`` for
+    # computed/FIFO rows and aggregates, which have no book ambiguity.
+    # Callers must not blend "day" rows with "net"/"holding" rows in a sum —
+    # a Kite day-book row for a position closed today is costed against a
+    # zero average price and can show a fabricated sign-inverted number.
+    scope: PnLScope | None = None
+    # True when this row's economics are anchored to a zero average price
+    # because the underlying position was fully squared off intraday
+    # (Kite's day-book convention) — a strong signal not to sum it in with
+    # net/holding pnl.
+    zero_avg_price_artifact: bool = False

--- a/lib/bandl/providers/crypto/coindcx/account.py
+++ b/lib/bandl/providers/crypto/coindcx/account.py
@@ -311,6 +311,7 @@ class CoinDCXAccountMixin:
         granularity: str = PnLGranularity.SYMBOL,
         prefer: str = "auto",
         reconcile: bool = False,
+        scope: str | None = None,  # no day/net ambiguity here; kept for uniform facet call
     ) -> list[PnLRecord]:
         if not filters.start or not filters.end:
             raise ProviderError(self.provider_id, "get_pnl requires start and end on filters")

--- a/lib/bandl/providers/equity/zerodha/account.py
+++ b/lib/bandl/providers/equity/zerodha/account.py
@@ -79,7 +79,12 @@ class ZerodhaAccountMixin:
                 supported=True,
                 max_history_days=1,
                 pagination="snapshot",
-                notes=["GET /portfolio/positions unrealized/realized fields (day snapshot)"],
+                notes=[
+                    "GET /portfolio/positions unrealized/realized fields (net + day books)",
+                    "get_pnl() defaults to scope=net+holding (safe to sum); pass "
+                    "scope='day' or scope='all' to see Kite's day-book view — day rows "
+                    "for positions squared off intraday carry zero_avg_price_artifact=True",
+                ],
             ),
             pnl_computed=CapabilityDetail(
                 supported=True,
@@ -282,7 +287,20 @@ class ZerodhaAccountMixin:
         granularity: str = PnLGranularity.SYMBOL,
         prefer: str = "auto",
         reconcile: bool = False,
+        scope: str | None = None,
     ) -> list[PnLRecord]:
+        """``scope``: ``None`` (default) returns net + holding rows only — safe to
+        sum. Pass ``"day"`` for Kite's day-book view, ``"net"``/``"holding"`` to
+        isolate one book, or ``"all"`` for every row including day-book. Day-book
+        rows for positions squared off intraday are costed against a zero average
+        price (Kite convention) and carry ``zero_avg_price_artifact=True`` — never
+        blend them with net/holding pnl in a sum.
+        """
+        if scope is not None and scope not in ("net", "day", "holding", "all"):
+            raise ProviderError(
+                self.provider_id,
+                f"Invalid scope={scope!r}; expected one of: net, day, holding, all",
+            )
         caps = self.account_capabilities()
         broker_rows: list[PnLRecord] = []
         seg_filter = (filters.segment or "").lower() if filters.segment else ""
@@ -310,6 +328,7 @@ class ZerodhaAccountMixin:
                             PnLRecord(
                                 pnl_id=f"broker:holding:{sym}",
                                 granularity=granularity,
+                                scope="holding",
                                 total_pnl=Decimal(str(pnl_val)) if pnl_val is not None else None,
                                 currency="INR",
                                 symbol=sym,
@@ -367,10 +386,27 @@ class ZerodhaAccountMixin:
                             unreal = row.get("unrealised")
                             real = row.get("realised")
                             total = row.get("pnl")
+                            avg_price = row.get("average_price")
+                            zero_avg_artifact = book == "day" and (
+                                avg_price is None or Decimal(str(avg_price)) == 0
+                            )
+                            row_warnings = [
+                                f"Snapshot from /portfolio/positions ({book}); "
+                                "session/day scope — not full calendar-month history",
+                            ]
+                            if zero_avg_artifact:
+                                row_warnings.append(
+                                    "Day-book row for a position squared off intraday — Kite "
+                                    "costs this against a zero average price; the pnl fields "
+                                    "here can be sign-inverted vs. true economics. Do not sum "
+                                    "with net/holding scope rows.",
+                                )
                             broker_rows.append(
                                 PnLRecord(
                                     pnl_id=f"broker:pos:{book}:{sym}",
                                     granularity=granularity,
+                                    scope=book,
+                                    zero_avg_price_artifact=zero_avg_artifact,
                                     realized_pnl=Decimal(str(real)) if real is not None else None,
                                     unrealized_pnl=Decimal(str(unreal))
                                     if unreal is not None
@@ -382,11 +418,10 @@ class ZerodhaAccountMixin:
                                     provenance=PnLProvenance(
                                         source_type=PnLSourceType.BROKER,
                                         includes_fees=False,
-                                        confidence=PnLConfidence.MEDIUM,
-                                        warnings=[
-                                            f"Snapshot from /portfolio/positions ({book}); "
-                                            "session/day scope — not full calendar-month history",
-                                        ],
+                                        confidence=PnLConfidence.LOW
+                                        if zero_avg_artifact
+                                        else PnLConfidence.MEDIUM,
+                                        warnings=row_warnings,
                                     ),
                                     source=self.provider_id,
                                     segment=seg,
@@ -400,20 +435,35 @@ class ZerodhaAccountMixin:
                                 ),
                             )
 
+        if scope == "all":
+            pass
+        elif scope in ("net", "day", "holding"):
+            broker_rows = [r for r in broker_rows if r.scope == scope]
+        else:
+            # default: net + holding only — day-book rows are excluded because
+            # they are not safe to sum alongside net/holding (see zero_avg_price_artifact).
+            broker_rows = [r for r in broker_rows if r.scope != "day"]
+
         computed_rows: list[PnLRecord] = []
         if prefer in ("auto", "computed", "hybrid") and caps.pnl_computed.supported:
             fills = self.get_fills(filters)
-            ledger = []
+            ledger: list[LedgerEntry] = []
+            computed_warnings = ["Session-limited fills; historical PnL may be incomplete"]
             try:
                 ledger = self.get_ledger_entries(filters)
             except UnsupportedCapabilityError:
                 pass
+            except ProviderError as err:
+                computed_warnings.append(
+                    f"Ledger/charges enrichment failed upstream ({err}); realized pnl "
+                    "excludes fees for this call — degraded, not crashed",
+                )
             computed_rows = compute_pnl_from_fills(
                 fills,
                 ledger=ledger,
                 source=self.provider_id,
                 granularity=granularity,
-                warnings=["Session-limited fills; historical PnL may be incomplete"],
+                warnings=computed_warnings,
             )
 
         if broker_rows and computed_rows and reconcile:

--- a/tests/bandl/test_capabilities.py
+++ b/tests/bandl/test_capabilities.py
@@ -6,6 +6,7 @@ import pytest
 
 from bandl import Bandl
 from bandl.config import BandlConfig
+from bandl.core.capabilities import AccountCapabilities
 from bandl.exceptions import ConfigurationError
 from bandl.providers.crypto.binance import BinanceProvider
 
@@ -19,3 +20,11 @@ def test_account_fills_binance_raises() -> None:
     client = Bandl()
     with pytest.raises(ConfigurationError, match="account history"):
         client.account.get_fills(source="binance")
+
+
+def test_account_capabilities_has_no_vestigial_positions_field() -> None:
+    """AccountCapabilities.positions predated PortfolioCapabilities.positions (the
+    real one, backing client.portfolio.get_positions), was never set True by any
+    provider, and was never read anywhere — removed rather than fixed to avoid
+    implying a get_positions() method that AccountHistoryProvider doesn't have."""
+    assert "positions" not in AccountCapabilities.model_fields

--- a/tests/bandl/test_pnl_scope.py
+++ b/tests/bandl/test_pnl_scope.py
@@ -1,0 +1,181 @@
+"""Zerodha get_pnl day/net/holding scope tests (fixes silent double-counting)."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from bandl.config import BandlConfig, ProviderSettings
+from bandl.core.account_filters import AccountFilters
+from bandl.exceptions import ProviderError
+from bandl.providers.equity.zerodha import ZerodhaProvider
+
+_HOLDINGS = [
+    {"tradingsymbol": "INFY", "pnl": 500.0},
+]
+
+_POSITIONS = {
+    "net": [
+        {
+            "tradingsymbol": "RELIANCE",
+            "exchange": "NFO",
+            "product": "NRML",
+            "quantity": 10,
+            "unrealised": -20.0,
+            "realised": 100.0,
+            "pnl": 80.0,
+        },
+    ],
+    "day": [
+        {
+            # squared off intraday -> Kite costs this at a zero average price
+            "tradingsymbol": "SBIN",
+            "exchange": "NFO",
+            "product": "MIS",
+            "quantity": 0,
+            "average_price": 0,
+            "unrealised": 0.0,
+            "realised": -40330.0,
+            "pnl": -40330.0,
+        },
+        {
+            # still open intraday, real average price -> not an artifact
+            "tradingsymbol": "TCS",
+            "exchange": "NFO",
+            "product": "MIS",
+            "quantity": 5,
+            "average_price": 3500.0,
+            "unrealised": 250.0,
+            "realised": 0.0,
+            "pnl": 250.0,
+        },
+    ],
+}
+
+
+def _provider() -> ZerodhaProvider:
+    return ZerodhaProvider(
+        BandlConfig(),
+        ProviderSettings(api_key="k", access_token="t"),
+    )
+
+
+def _fake_get(url: str, *, provider: str, params=None, headers=None):
+    if url.endswith("/portfolio/holdings"):
+        return {"status": "success", "data": _HOLDINGS}
+    if url.endswith("/portfolio/positions"):
+        return {"status": "success", "data": _POSITIONS}
+    if url.endswith("/orders"):
+        return {"status": "success", "data": []}
+    if url.endswith("/trades"):
+        return {"status": "success", "data": []}
+    return {"status": "success", "data": []}
+
+
+def test_default_scope_excludes_day_book() -> None:
+    prov = _provider()
+    prov._http.get_json = _fake_get
+
+    rows = prov.get_pnl(AccountFilters(), prefer="broker")
+    assert rows  # net + holding present
+    assert all(r.scope != "day" for r in rows)
+    scopes = {r.scope for r in rows}
+    assert scopes == {"net", "holding"}
+
+
+def test_scope_day_isolates_day_book_and_flags_zero_avg() -> None:
+    prov = _provider()
+    prov._http.get_json = _fake_get
+
+    rows = prov.get_pnl(AccountFilters(), prefer="broker", scope="day")
+    assert len(rows) == 2
+    assert all(r.scope == "day" for r in rows)
+
+    sbin = next(r for r in rows if r.symbol_native == "SBIN")
+    assert sbin.zero_avg_price_artifact is True
+    assert sbin.provenance.confidence == "low"
+
+    tcs = next(r for r in rows if r.symbol_native == "TCS")
+    assert tcs.zero_avg_price_artifact is False
+
+
+def test_scope_all_returns_every_book() -> None:
+    prov = _provider()
+    prov._http.get_json = _fake_get
+
+    rows = prov.get_pnl(AccountFilters(), prefer="broker", scope="all")
+    scopes = [r.scope for r in rows]
+    assert scopes.count("net") == 1
+    assert scopes.count("day") == 2
+    assert scopes.count("holding") == 1
+
+
+def test_scope_net_isolates_net_only() -> None:
+    prov = _provider()
+    prov._http.get_json = _fake_get
+
+    rows = prov.get_pnl(AccountFilters(), prefer="broker", scope="net")
+    assert len(rows) == 1
+    assert rows[0].scope == "net"
+    assert rows[0].symbol_native == "RELIANCE"
+
+
+def test_invalid_scope_raises() -> None:
+    prov = _provider()
+    prov._http.get_json = _fake_get
+    with pytest.raises(ProviderError):
+        prov.get_pnl(AccountFilters(), prefer="broker", scope="bogus")
+
+
+def _fake_get_with_one_order(url: str, *, provider: str, params=None, headers=None):
+    if url.endswith("/portfolio/holdings"):
+        return {"status": "success", "data": []}
+    if url.endswith("/portfolio/positions"):
+        return {"status": "success", "data": {"net": [], "day": []}}
+    if url.endswith("/orders"):
+        return {
+            "status": "success",
+            "data": [
+                {
+                    "order_id": "1",
+                    "exchange": "NSE",
+                    "tradingsymbol": "RELIANCE",
+                    "transaction_type": "BUY",
+                    "order_type": "MARKET",
+                    "status": "COMPLETE",
+                    "quantity": 1,
+                    "filled_quantity": 1,
+                    "order_timestamp": "2026-07-08 10:00:00+05:30",
+                    "product": "CNC",
+                },
+            ],
+        }
+    if url.endswith("/trades"):
+        return {"status": "success", "data": []}
+    return {"status": "success", "data": []}
+
+
+def test_ledger_failure_degrades_instead_of_crashing() -> None:
+    prov = _provider()
+    prov._http.get_json = _fake_get_with_one_order
+    prov._http.post_json = MagicMock(
+        side_effect=ProviderError("zerodha", "HTTP 500 for /charges/orders: boom"),
+    )
+
+    # Must not raise, even though /charges/orders 500s.
+    rows = prov.get_pnl(AccountFilters(), prefer="computed")
+    assert isinstance(rows, list)
+    if rows:
+        assert any("degraded" in w for w in rows[0].provenance.warnings)
+
+
+def test_reconcile_true_does_not_crash_on_ledger_failure() -> None:
+    prov = _provider()
+    prov._http.get_json = _fake_get_with_one_order
+    prov._http.post_json = MagicMock(
+        side_effect=ProviderError("zerodha", "HTTP 500 for /charges/orders: boom"),
+    )
+
+    rows = prov.get_pnl(AccountFilters(), prefer="auto", reconcile=True)
+    assert isinstance(rows, list)

--- a/tests/bandl/test_pnl_summary.py
+++ b/tests/bandl/test_pnl_summary.py
@@ -1,0 +1,82 @@
+"""AccountFacet.get_pnl_summary — sum-safe rollup per symbol."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from decimal import Decimal
+from unittest.mock import MagicMock
+
+from bandl import Bandl
+from bandl.models.account import PnLProvenance, PnLRecord
+from bandl.models.account.types import PnLConfidence, PnLSourceType, Segment
+
+
+def _row(
+    pnl_id: str,
+    *,
+    symbol: str,
+    scope,
+    realized=None,
+    unrealized=None,
+    total=None,
+    confidence=PnLConfidence.MEDIUM,
+) -> PnLRecord:
+    return PnLRecord(
+        pnl_id=pnl_id,
+        granularity="symbol",
+        scope=scope,
+        realized_pnl=realized,
+        unrealized_pnl=unrealized,
+        total_pnl=total,
+        currency="INR",
+        symbol=symbol,
+        symbol_native=symbol.split(":")[-1],
+        as_of=datetime.now(timezone.utc),
+        provenance=PnLProvenance(source_type=PnLSourceType.BROKER, confidence=confidence),
+        source="zerodha",
+        segment=Segment.EQUITY_FNO,
+        provider_native={},
+        dedup_key=f"zerodha:pnl:{pnl_id}",
+    )
+
+
+def test_get_pnl_summary_sums_across_scopes_safely() -> None:
+    client = Bandl()
+    net_row = _row(
+        "broker:pos:net:NFO:RELIANCE",
+        symbol="NFO:RELIANCE",
+        scope="net",
+        realized=Decimal(100),
+        unrealized=Decimal(-20),
+        total=Decimal(80),
+    )
+    holding_row = _row(
+        "broker:holding:NFO:RELIANCE",
+        symbol="NFO:RELIANCE",
+        scope="holding",
+        total=Decimal(30),
+        confidence=PnLConfidence.LOW,
+    )
+    client.account.get_pnl = MagicMock(return_value=[net_row, holding_row])
+
+    summary = client.account.get_pnl_summary(source="zerodha")
+    assert len(summary) == 1
+    row = summary[0]
+    assert row.symbol == "NFO:RELIANCE"
+    assert row.realized_pnl == Decimal(100)
+    assert row.unrealized_pnl == Decimal(-20)
+    assert row.total_pnl == Decimal(110)  # 80 (net) + 30 (holding), never blended with day
+    assert row.provenance.confidence == PnLConfidence.LOW  # worst-case of contributing rows
+    assert "broker:pos:net:NFO:RELIANCE" in row.metadata["contributing_pnl_ids"]
+
+
+def test_get_pnl_summary_handles_total_only_rows() -> None:
+    client = Bandl()
+    row = _row("broker:holding:NSE:INFY", symbol="NSE:INFY", scope="holding", total=Decimal(500))
+    client.account.get_pnl = MagicMock(return_value=[row])
+
+    summary = client.account.get_pnl_summary(source="zerodha")
+    assert len(summary) == 1
+    assert summary[0].total_pnl == Decimal(500)
+    assert summary[0].realized_pnl is None
+    assert summary[0].unrealized_pnl is None


### PR DESCRIPTION
## Summary
- Kite's `/portfolio/positions` returns two books — `net` (true running position economics) and `day` (today's session view). A position squared off intraday is costed by Kite against a **zero average price** in the day book, which can invert the sign of that row's pnl. `client.account.get_pnl()` for Zerodha returned both books together with no typed way to tell them apart — only prose in `provenance.warnings` — so a naive `sum()` over all rows silently blended real net pnl with fabricated day-book numbers. Reported live: true net pnl +68,800, naive sum of all rows -40,330.
- `PnLRecord` gains `scope: Literal["day","net","holding"] | None` and `zero_avg_price_artifact: bool`.
- `get_pnl()` now defaults to `net`+`holding` scope only (safe to sum); day-book requires explicit `scope="day"`/`"all"`.
- Added `client.account.get_pnl_summary()` — one sum-safe row per symbol, so callers don't have to hand-roll day/net reconciliation.
- Broadened the ledger-enrichment try/except in `get_pnl()` to catch `ProviderError` (not just `UnsupportedCapabilityError`) — previously a single order causing Kite's `/charges/orders` to 500 crashed the *entire* `get_pnl()` call (not just when `reconcile=True` — this path runs by default whenever `prefer` is `auto`/`computed`/`hybrid`). Now degrades to unreconciled pnl with a warning.
- Removed `AccountCapabilities.positions` — a vestigial field, never set `True` by any provider and never read anywhere, that contradicted `pnl_broker`'s own notes about being positions-derived. Superseded by the real `PortfolioCapabilities.positions` (`client.portfolio`, from #63).

## Test plan
- [x] `pytest tests/bandl/` — 102/102 passing (10 new tests in `test_pnl_scope.py`, `test_pnl_summary.py`, `test_capabilities.py`).
- [x] `ruff check` / `ruff format --check` clean.
- [x] Verified via code read that CoinDCX's `get_pnl` has no day/net split — fix is Zerodha-specific, CoinDCX just accepts the new `scope` kwarg for uniform facet calling and ignores it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)